### PR TITLE
Add native Apple Sign-In using ASAuthorizationAppleIDProvider

### DIFF
--- a/app/flyfun-forms/flyfun-forms/Services/AuthService.swift
+++ b/app/flyfun-forms/flyfun-forms/Services/AuthService.swift
@@ -2,7 +2,7 @@ import AuthenticationServices
 import Foundation
 import OSLog
 
-/// Handles OAuth login via ASWebAuthenticationSession (Google, Apple, etc.).
+/// Handles OAuth login via ASWebAuthenticationSession (Google) and native Apple Sign-In.
 @MainActor
 final class AuthService: NSObject, ASWebAuthenticationPresentationContextProviding {
     private static let logger = Logger(subsystem: "net.ro-z.flyfun-forms", category: "Auth")
@@ -60,5 +60,121 @@ final class AuthService: NSObject, ASWebAuthenticationPresentationContextProvidi
             throw URLError(.userAuthenticationRequired)
         }
         return token
+    }
+
+    // MARK: - Native Apple Sign-In
+
+    /// Uses ASAuthorizationAppleIDProvider to sign in natively, then exchanges the
+    /// identity token with the server for a JWT.
+    func signInWithApple(baseURL: URL) async throws -> String {
+        let credential = try await performAppleAuthorization()
+
+        guard let identityTokenData = credential.identityToken,
+              let identityToken = String(data: identityTokenData, encoding: .utf8)
+        else {
+            Self.logger.error("No identity token in Apple credential")
+            throw URLError(.userAuthenticationRequired)
+        }
+
+        // Apple only provides the name on the very first authorization.
+        // Send it to the server so it can be stored with the user record.
+        let firstName = credential.fullName?.givenName
+        let lastName = credential.fullName?.familyName
+
+        Self.logger.info("Exchanging Apple identity token (name: \(firstName ?? "nil") \(lastName ?? "nil"))")
+
+        return try await exchangeAppleToken(
+            baseURL: baseURL,
+            identityToken: identityToken,
+            firstName: firstName,
+            lastName: lastName
+        )
+    }
+
+    private func performAppleAuthorization() async throws -> ASAuthorizationAppleIDCredential {
+        let provider = ASAuthorizationAppleIDProvider()
+        let request = provider.createRequest()
+        request.requestedScopes = [.fullName, .email]
+
+        return try await withCheckedThrowingContinuation { continuation in
+            let delegate = AppleSignInDelegate(continuation: continuation)
+            let controller = ASAuthorizationController(authorizationRequests: [request])
+            controller.delegate = delegate
+            // Keep delegate alive until callback fires
+            objc_setAssociatedObject(controller, "delegate", delegate, .OBJC_ASSOCIATION_RETAIN)
+            #if os(iOS)
+            controller.performRequests()
+            #else
+            controller.performRequests()
+            #endif
+        }
+    }
+
+    /// POST the Apple identity token to /auth/apple/token and return the JWT.
+    private func exchangeAppleToken(
+        baseURL: URL,
+        identityToken: String,
+        firstName: String?,
+        lastName: String?
+    ) async throws -> String {
+        let url = baseURL.appendingPathComponent("auth/apple/token")
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        var body: [String: String] = ["identity_token": identityToken]
+        if let firstName { body["first_name"] = firstName }
+        if let lastName { body["last_name"] = lastName }
+
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw URLError(.badServerResponse)
+        }
+        guard httpResponse.statusCode == 200 else {
+            let detail = String(data: data, encoding: .utf8) ?? "Unknown error"
+            Self.logger.error("Apple token exchange failed (\(httpResponse.statusCode)): \(detail)")
+            throw URLError(.userAuthenticationRequired)
+        }
+
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let token = json["token"] as? String
+        else {
+            throw URLError(.cannotParseResponse)
+        }
+        return token
+    }
+}
+
+// MARK: - ASAuthorizationControllerDelegate
+
+/// Bridges ASAuthorizationController's delegate callbacks into async/await.
+private final class AppleSignInDelegate: NSObject, ASAuthorizationControllerDelegate {
+    private var continuation: CheckedContinuation<ASAuthorizationAppleIDCredential, Error>?
+
+    init(continuation: CheckedContinuation<ASAuthorizationAppleIDCredential, Error>) {
+        self.continuation = continuation
+    }
+
+    func authorizationController(
+        controller: ASAuthorizationController,
+        didCompleteWithAuthorization authorization: ASAuthorization
+    ) {
+        if let credential = authorization.credential as? ASAuthorizationAppleIDCredential {
+            continuation?.resume(returning: credential)
+        } else {
+            continuation?.resume(throwing: URLError(.userAuthenticationRequired))
+        }
+        continuation = nil
+    }
+
+    func authorizationController(
+        controller: ASAuthorizationController,
+        didCompleteWithError error: Error
+    ) {
+        continuation?.resume(throwing: error)
+        continuation = nil
     }
 }

--- a/app/flyfun-forms/flyfun-forms/Services/AuthService.swift
+++ b/app/flyfun-forms/flyfun-forms/Services/AuthService.swift
@@ -102,11 +102,7 @@ final class AuthService: NSObject, ASWebAuthenticationPresentationContextProvidi
             controller.delegate = delegate
             // Keep delegate alive until callback fires
             objc_setAssociatedObject(controller, "delegate", delegate, .OBJC_ASSOCIATION_RETAIN)
-            #if os(iOS)
             controller.performRequests()
-            #else
-            controller.performRequests()
-            #endif
         }
     }
 

--- a/app/flyfun-forms/flyfun-forms/Views/LoginView.swift
+++ b/app/flyfun-forms/flyfun-forms/Views/LoginView.swift
@@ -72,7 +72,10 @@ struct LoginView: View {
         defer { isSigningIn = false }
         do {
             let token = try await authService.signInWithApple(baseURL: APIConfig.baseURL)
-            let callbackURL = URL(string: "flyfunforms://auth/callback?token=\(token)")!
+            guard let callbackURL = URL(string: "flyfunforms://auth/callback?token=\(token)") else {
+                errorMessage = "Failed to create authentication URL."
+                return
+            }
             appState.handleAuthCallback(url: callbackURL)
         } catch {
             if (error as? ASAuthorizationError)?.code != .canceled {
@@ -87,7 +90,10 @@ struct LoginView: View {
         defer { isSigningIn = false }
         do {
             let token = try await authService.signIn(baseURL: APIConfig.baseURL, provider: provider)
-            let callbackURL = URL(string: "flyfunforms://auth/callback?token=\(token)")!
+            guard let callbackURL = URL(string: "flyfunforms://auth/callback?token=\(token)") else {
+                errorMessage = "Failed to create authentication URL."
+                return
+            }
             appState.handleAuthCallback(url: callbackURL)
         } catch {
             if (error as? ASWebAuthenticationSessionError)?.code != .canceledLogin {

--- a/app/flyfun-forms/flyfun-forms/Views/LoginView.swift
+++ b/app/flyfun-forms/flyfun-forms/Views/LoginView.swift
@@ -33,6 +33,14 @@ struct LoginView: View {
                     .padding(.horizontal)
             }
 
+            SignInWithAppleButton(.signIn) { _ in
+                Task { await signInWithApple() }
+            }
+            .signInWithAppleButtonStyle(.black)
+            .frame(maxWidth: 280, minHeight: 50)
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .disabled(isSigningIn)
+
             Button {
                 Task { await signIn(provider: "google") }
             } label: {
@@ -56,6 +64,21 @@ struct LoginView: View {
                 .frame(height: 60)
         }
         .padding()
+    }
+
+    private func signInWithApple() async {
+        isSigningIn = true
+        errorMessage = nil
+        defer { isSigningIn = false }
+        do {
+            let token = try await authService.signInWithApple(baseURL: APIConfig.baseURL)
+            let callbackURL = URL(string: "flyfunforms://auth/callback?token=\(token)")!
+            appState.handleAuthCallback(url: callbackURL)
+        } catch {
+            if (error as? ASAuthorizationError)?.code != .canceled {
+                errorMessage = error.localizedDescription
+            }
+        }
     }
 
     private func signIn(provider: String) async {

--- a/app/flyfun-forms/flyfun-forms/flyfun-forms.entitlements
+++ b/app/flyfun-forms/flyfun-forms/flyfun-forms.entitlements
@@ -14,6 +14,10 @@
 	<array>
 		<string>CloudKit</string>
 	</array>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
 	<key>com.apple.security.network.client</key>
 	<true/>
 </dict>

--- a/app/flyfun-forms/flyfun-forms/flyfun_forms.entitlements
+++ b/app/flyfun-forms/flyfun-forms/flyfun_forms.entitlements
@@ -6,6 +6,10 @@
 	<string>development</string>
 	<key>com.apple.developer.aps-environment</key>
 	<string>development</string>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
 	<key>com.apple.security.network.client</key>
 	<true/>
 	<key>com.apple.developer.icloud-container-identifiers</key>

--- a/designs/ios-app.md
+++ b/designs/ios-app.md
@@ -29,7 +29,7 @@ app/flyfun-forms/flyfun-forms/
 └── Services/
     ├── AppState.swift         # @Observable: JWT auth state, token storage
     ├── Environment.swift      # APIConfig (base URL, simulator vs device)
-    ├── AuthService.swift      # OAuth via ASWebAuthenticationSession
+    ├── AuthService.swift      # Google OAuth + native Apple Sign-In
     ├── FormService.swift      # API client for /airports, /generate, /validate
     ├── DocumentResolver.swift # Picks best document per person + airport region
     ├── AirportCatalog.swift   # Airport/form discovery with server sync
@@ -45,14 +45,22 @@ app/flyfun-forms/flyfun-forms/
 
 ### Auth Flow
 
-Uses [flyfun-common OAuth](../../flyfun-common/designs/auth.md) with iOS-specific redirect:
+Uses [flyfun-common OAuth](../../flyfun-common/designs/auth.md):
 
+**Google:** Web OAuth via `ASWebAuthenticationSession`
 1. User taps "Sign in with Google" on `LoginView`
 2. `AuthService` opens `ASWebAuthenticationSession` → `https://forms.flyfun.aero/auth/login/google?platform=ios&scheme=flyfunforms`
 3. Server handles OAuth, redirects to `flyfunforms://auth/callback?token=<JWT>`
 4. `AppState` captures callback URL, extracts JWT, stores in keychain via `CodableSecureStorage` (from RZUtilsSwift)
-5. All API requests include `Authorization: Bearer <JWT>` header
-6. On logout, JWT cleared from keychain
+
+**Apple:** Native `ASAuthorizationAppleIDProvider`
+1. User taps the system "Sign in with Apple" button on `LoginView`
+2. `AuthService.signInWithApple()` presents the native Apple Sign-In sheet via `ASAuthorizationController`
+3. On success, extracts the identity token and user's name (name only provided on first authorization)
+4. POSTs identity token + first/last name to `POST /auth/apple/token`
+5. Server validates token against Apple's JWKS keys, creates/updates user (storing name on first login), returns a flyfun JWT
+
+**Common:** All API requests include `Authorization: Bearer <JWT>` header. On logout, JWT cleared from keychain.
 
 ### API Integration
 
@@ -112,7 +120,8 @@ if appState.isAuthenticated {
 
 - **SwiftData over Core Data:** Modern API, native CloudKit integration, less boilerplate. Requires iOS 17+.
 - **CloudKit private DB for PII:** Apple handles encryption. No custom encryption layer needed. Cross-device sync is automatic.
-- **ASWebAuthenticationSession:** System-provided OAuth UI. Handles Safari cookie sharing and secure callback. No embedded WebView.
+- **Native Apple Sign-In:** Uses `ASAuthorizationAppleIDProvider` for polished system UI. Identity token exchanged server-side via `POST /auth/apple/token`. Name captured and stored on first authorization only.
+- **ASWebAuthenticationSession for Google:** System-provided OAuth UI. Handles Safari cookie sharing and secure callback. No embedded WebView.
 - **JWT in keychain:** Using RZUtilsSwift's `CodableSecureStorage` for secure, typed token storage.
 - **URL scheme `flyfunforms://`:** For OAuth callback redirect from server back to app.
 - **Multi-document per person:** Real pilots carry multiple passports/IDs. Document selection is automatic per region but overridable. Nationality derived from document, not stored on person.


### PR DESCRIPTION
Uses the native iOS/macOS Apple Sign-In flow instead of web OAuth for a
polished system UI experience. The identity token is exchanged server-side
via POST /auth/apple/token (provided by flyfun-common). User's name is
captured and sent on first authorization since Apple only provides it once.

https://claude.ai/code/session_01R1dmPTSuj4QHHhuX4Rekxr